### PR TITLE
Appengine-magic fixes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,13 @@
-(defproject appengine-magic "0.2.1"
+(defproject appengine-magic "0.2.2-SNAPSHOT"
   :description "Google App Engine library for Clojure."
   :repositories {"maven-gae-plugin" "http://maven-gae-plugin.googlecode.com/svn/repository"}
-  :dependencies [[org.clojure/clojure "1.2.0"]
+  :namespaces [appengine-magic.core appengine-magic.servlet appengine-magic.utils appengine-magic.testing]
+  :dependencies [[org.clojure/clojure "1.3.0-SNAPSHOT"]
                  [ring/ring-core "0.3.2"]
-                 [com.google.appengine/appengine-api-1.0-sdk "1.3.7"]
-                 [com.google.appengine/appengine-api-labs "1.3.7"]
-                 [com.google.appengine/appengine-api-stubs "1.3.7"]
+                 [com.google.appengine/appengine-api-1.0-sdk "1.3.8"]
+                 [com.google.appengine/appengine-api-labs "1.3.8"]
+                 [com.google.appengine/appengine-api-stubs "1.3.8"]
+                 [com.google.appengine/appengine-testing "1.3.8"]
                  [com.google.appengine/appengine-local-runtime "1.3.7"]
-                 [com.google.appengine/appengine-testing "1.3.7"]
                  [com.google.appengine/appengine-tools-api "1.3.7"]]
   :dev-dependencies [[swank-clojure "1.2.1"]])

--- a/src/appengine_magic/servlet.clj
+++ b/src/appengine_magic/servlet.clj
@@ -42,7 +42,7 @@
 
 (defn- make-request-map [^HttpServlet servlet
                          ^HttpServletRequest request
-                         ^HttpServletRespone response]
+                         ^HttpServletResponse response]
   {:servlet            servlet
    :response           response
    :request            request


### PR DESCRIPTION
Hi gcv,

I have two small patches for appengine-magic.

First one fixes a typo in type hint for HttpServletResponse which prevented compilation.

Other patch updates appengine to 1.3.8 where available and adds key namespaces to be precompiled, in order to speed up compilation in projects depending on appengine-magic.

Thanks,
Marko
