### PR TITLE
Use value of $APPENGINE_HOME as a fallback for SDK location

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,9 @@ new entry in `project.clj` manages applications and versions.
                        "bob"     "/Users/bob/lib/appengine-java-sdk"
                        "charlie" "/home/charlie/appengine/sdk/current"}
 
+   If the APPENGINE_HOME environment variable is set, its value will
+   be used if no :appengine-sdk entry is found in the project.clj
+   file.
 4. Run `lein appengine-update <application>`, where the argument is an
    application name from the `:appengine-app-versions` map.
 

--- a/src/appengine_magic/leiningen_helpers.clj
+++ b/src/appengine_magic/leiningen_helpers.clj
@@ -11,7 +11,9 @@
         appengine-sdk (cond
                        ;; not given
                        (nil? appengine-sdk)
-                       (lein/abort (str task-name "requires :appengine-sdk in project.clj"))
+		       (if-let [from-env (System/getenv "APPENGINE_HOME")]
+			 from-env
+			 (lein/abort (str task-name "no App Engine SDK specified: set :appengine-sdk in project.clj, or APPENGINE_HOME in the environment")))
                        ;; a string
                        (string? appengine-sdk)
                        appengine-sdk


### PR DESCRIPTION
If the environment variable APPENGINE_HOME is set, use its value if
there is no explicit setting for :appengine-sdk in the project.clj.
