### PR TITLE
Make the dev server apply appropriate Content-Type and Last-Modified headers to static files.

### DIFF
--- a/src/appengine_magic/core_local.clj
+++ b/src/appengine_magic/core_local.clj
@@ -3,7 +3,8 @@
 (use 'appengine-magic.local-env-helpers
      '[appengine-magic.servlet :only [servlet]]
      '[appengine-magic.swank :only [wrap-swank]]
-     '[ring.middleware.file :only [wrap-file]])
+     '[ring.middleware.file :only [wrap-file]]
+     '[ring.middleware.file-info :only [wrap-file-info]])
 
 (require '[clojure.string :as str]
          '[appengine-magic.jetty :as jetty]
@@ -39,7 +40,7 @@
     (let [#^String uri (:uri req)]
       (if (.startsWith uri "/WEB-INF")
           (app req)
-          ((wrap-file app war-root) req)))))
+          (do (println "Here") ((wrap-file-info (wrap-file app war-root)) req))))))
 
 
 (defmacro def-appengine-app [app-var-name handler & {:keys [war-root]}]

--- a/src/appengine_magic/core_local.clj
+++ b/src/appengine_magic/core_local.clj
@@ -40,7 +40,7 @@
     (let [#^String uri (:uri req)]
       (if (.startsWith uri "/WEB-INF")
           (app req)
-          (do (println "Here") ((wrap-file-info (wrap-file app war-root)) req))))))
+          ((wrap-file-info (wrap-file app war-root)) req)))))
 
 
 (defmacro def-appengine-app [app-var-name handler & {:keys [war-root]}]


### PR DESCRIPTION
Hey, I just applied a small patch to make the local dev server apply the headers listed in the the subject line. This is accomplished by adding ring.middleware.file-info/wrap-file-info to appengine-magic.core/wrap-war-static.

I did this because my CSS files weren't getting loaded by IE9. IE9 refused to load the CSS, because (in a nutshell) it thinks it is being more secure to ignore CSS that the server doesn't mark as CSS in the response headers.

FYI, I also issued this pull request to ctran.
