### PR TITLE
Added wrap-file-info for the local server

### DIFF
--- a/src/appengine_magic/core_local.clj
+++ b/src/appengine_magic/core_local.clj
@@ -3,7 +3,8 @@
 (use 'appengine-magic.local-env-helpers
      '[appengine-magic.servlet :only [servlet]]
      '[appengine-magic.swank :only [wrap-swank]]
-     '[ring.middleware.file :only [wrap-file]])
+     '[ring.middleware.file :only [wrap-file]]
+     '[ring.middleware.file-info :only [wrap-file-info]])
 
 (require '[clojure.string :as str]
          '[appengine-magic.jetty :as jetty]
@@ -39,7 +40,7 @@
     (let [#^String uri (:uri req)]
       (if (.startsWith uri "/WEB-INF")
           (app req)
-          ((wrap-file app war-root) req)))))
+          ((wrap-file-info (wrap-file app war-root)) req)))))
 
 
 (defmacro def-appengine-app [app-var-name handler & {:keys [war-root]}]


### PR DESCRIPTION
Hi,
i just added a wrap-file-info when serving static files from the local server so the browser doesn't complain about wrong mime-types (in our case ~300 messages on a page load while using uncompiled js).

Would be nice if it could be merged into the master (if the code seems fine to you, obviously).

Commit:
Wrapping static files for the local server with file-info so the mime-type is added

Have a nice day and thanks for the great library,
Tobias

P.S. It was nice talking to you (altho it wasn't too much) at the BA Clojure Group in May.
