### PR TITLE
added support for referencelists

### DIFF
--- a/src/appengine_magic/services/datastore.clj
+++ b/src/appengine_magic/services/datastore.clj
@@ -164,6 +164,9 @@
    (cond (instance? clojure.lang.APersistentMap v) (to-java-hashmap v) ; broken in GAE 1.3.7
          (instance? clojure.lang.APersistentSet v) (to-java-hashset v) ; broken in GAE 1.3.7
          (extends? EntityProtocol (class v)) (get-key-object v)
+	 (or (instance? clojure.lang.PersistentList v)
+	     (instance? clojure.lang.PersistentVector v))
+	 (map #(if (extends? EntityProtocol (class %)) (get-key-object %) %) v) ; ReferenceList support
          :else v)))
 
 


### PR DESCRIPTION
coerce-clojure-type now checks if v is a list or vector. if it is, it goes through the list/vector and gets the key for any entity objects in it
