### PR TITLE
servlet-api doesn't need to be deployed to appengine.

### DIFF
--- a/src/leiningen/appengine_prepare.clj
+++ b/src/leiningen/appengine_prepare.clj
@@ -43,7 +43,7 @@
       (lancet/copy {:todir (.getPath target-lib-dir)}
                    (lancet/fileset
                     {:dir lib-dev-dir
-                     :includes (str "appengine-magic*,ring-core*,servlet-api*,"
+                     :includes (str "appengine-magic*,ring-core*,"
                                     "commons-io*,commons-codec*,commons-fileupload*,"
                                     "appengine-api-1.0-sdk*,appengine-api-labs*")})))
     ;; Projects which do not normally use AOT may need some cleanup. This should


### PR DESCRIPTION
Appengine itself runs on jetty and doesn't need servlet-api on runtime, so it could be safely removed from appengine-prepare task.
