### PR TITLE
Updated depdendency to Appengine SDK 1.5.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,11 +18,11 @@
                  [taglibs/standard "1.1.2"] ; repackaged-appengine-jakarta-standard-1.1.2.jar
                  [commons-el "1.0"]
                  ;; main App Engine libraries
-                 [com.google.appengine/appengine-api-1.0-sdk "1.5.3"]
-                 [com.google.appengine/appengine-api-labs "1.5.3"]
-                 [com.google.appengine/appengine-api-stubs "1.5.3"]
-                 [com.google.appengine/appengine-local-runtime "1.5.3"]
-                 [com.google.appengine/appengine-local-runtime-shared "1.5.3"]
-                 [com.google.appengine/appengine-testing "1.5.3"]
-                 [com.google.appengine/appengine-tools-api "1.5.3"]]
+                 [com.google.appengine/appengine-api-1.0-sdk "1.5.4"]
+                 [com.google.appengine/appengine-api-labs "1.5.4"]
+                 [com.google.appengine/appengine-api-stubs "1.5.4"]
+                 [com.google.appengine/appengine-local-runtime "1.5.4"]
+                 [com.google.appengine/appengine-local-runtime-shared "1.5.4"]
+                 [com.google.appengine/appengine-testing "1.5.4"]
+                 [com.google.appengine/appengine-tools-api "1.5.4"]]
   :dev-dependencies [[swank-clojure "1.3.1" :exclusions [org.clojure/clojure]]])


### PR DESCRIPTION
All tests work and it creates no errors (we are using a patched version in production)
