### PR TITLE
Depending on Appengine-SDK 1.5.4 and fixed an Issue regarding the LocalImageService

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,11 +18,11 @@
                  [taglibs/standard "1.1.2"] ; repackaged-appengine-jakarta-standard-1.1.2.jar
                  [commons-el "1.0"]
                  ;; main App Engine libraries
-                 [com.google.appengine/appengine-api-1.0-sdk "1.5.3"]
-                 [com.google.appengine/appengine-api-labs "1.5.3"]
-                 [com.google.appengine/appengine-api-stubs "1.5.3"]
-                 [com.google.appengine/appengine-local-runtime "1.5.3"]
-                 [com.google.appengine/appengine-local-runtime-shared "1.5.3"]
-                 [com.google.appengine/appengine-testing "1.5.3"]
-                 [com.google.appengine/appengine-tools-api "1.5.3"]]
+                 [com.google.appengine/appengine-api-1.0-sdk "1.5.4"]
+                 [com.google.appengine/appengine-api-labs "1.5.4"]
+                 [com.google.appengine/appengine-api-stubs "1.5.4"]
+                 [com.google.appengine/appengine-local-runtime "1.5.4"]
+                 [com.google.appengine/appengine-local-runtime-shared "1.5.4"]
+                 [com.google.appengine/appengine-testing "1.5.4"]
+                 [com.google.appengine/appengine-tools-api "1.5.4"]]
   :dev-dependencies [[swank-clojure "1.3.1" :exclusions [org.clojure/clojure]]])

--- a/src/appengine_magic/local_env_helpers.clj
+++ b/src/appengine_magic/local_env_helpers.clj
@@ -39,6 +39,7 @@
                       (enforceApiDeadlines [] true)
                       (simulateProductionLatencies [] true)
                       (getAppDir [] dir)
+                      (getHostName [] "localhost")
                       (getAddress [] "localhost")
                       (getPort [] port)
                       (waitForServerToStart [] nil))


### PR DESCRIPTION
I increased the dependencies to GAE-SDK 1.5.4 and fixed the LocalServerEnvironmentProxy to supply a new function that is now needed so the local ImageService works again.
