### PR TITLE
Fix run-after-load for retrieve of single entity.

### DIFF
--- a/src/appengine_magic/services/datastore.clj
+++ b/src/appengine_magic/services/datastore.clj
@@ -362,10 +362,11 @@
         (let [key-object (make-key-from-value key-value-or-values parent)
               entity (.get (get-datastore-service) key-object)
               raw-properties (into {} (.getProperties entity))
-              entity-record (run-after-load (record entity-record-type))]
+              entity-record (record entity-record-type)]
           (with-meta
-            (merge entity-record (entity->properties raw-properties
-                                                     (get-clj-properties entity-record)))
+            (run-after-load
+              (merge entity-record (entity->properties raw-properties
+                                                      (get-clj-properties entity-record))))
             {:key (.getKey entity)})))))
 
 


### PR DESCRIPTION
run-after-load was being called, but in the wrong place, so its results were dropped.
