### PR TITLE
Appengine SDK 1.6.3.1 and local High-Replication-Datastore

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,12 @@
+## 0.4.9 (2012-03-15)
+
+* Add servlet LocalApiProxy property to container to fix LocalChannelServlet
+  and others. (Christoph Mewes)
+
+## 0.4.8 (2012-03-14)
+
+* Added option to use high replication datastore localy. (Christoph Mewes)
+
 ## 0.4.7 (2012-02-13)
 
 * Fixed a bug in the application order of `:after-load` hooks (thanks to Shawn

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject appengine-magic "0.4.7"
+(defproject appengine-magic "0.4.8"
   :description "Google App Engine library for Clojure."
   :min-lein-version "1.6.1"
   :repositories {"releases" "http://appengine-magic-mvn.googlecode.com/svn/releases/"
@@ -18,12 +18,12 @@
                  [taglibs/standard "1.1.2"] ; repackaged-appengine-jakarta-standard-1.1.2.jar
                  [commons-el "1.0"]
                  ;; main App Engine libraries
-                 [com.google.appengine/appengine-api-1.0-sdk "1.5.5"]
-                 [com.google.appengine/appengine-api-labs "1.5.5"]
-                 [com.google.appengine/appengine-api-stubs "1.5.5"]
-                 [com.google.appengine/appengine-local-runtime "1.5.5"]
-                 [com.google.appengine/appengine-local-runtime-shared "1.5.5"]
-                 [com.google.appengine/appengine-testing "1.5.5"]
-                 [com.google.appengine/appengine-tools-api "1.5.5"]]
+                 [com.google.appengine/appengine-api-1.0-sdk "1.6.3.1"]
+                 [com.google.appengine/appengine-api-labs "1.6.3.1"]
+                 [com.google.appengine/appengine-api-stubs "1.6.3.1"]
+                 [com.google.appengine/appengine-local-runtime "1.6.3.1"]
+                 [com.google.appengine/appengine-local-runtime-shared "1.6.3.1"]
+                 [com.google.appengine/appengine-testing "1.6.3.1"]
+                 [com.google.appengine/appengine-tools-api "1.6.3.1"]]
   :dev-dependencies [[org.clojure/clojure "1.2.1"]
                      [swank-clojure "1.4.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject appengine-magic "0.4.8"
+(defproject appengine-magic "0.4.9"
   :description "Google App Engine library for Clojure."
   :min-lein-version "1.6.1"
   :repositories {"releases" "http://appengine-magic-mvn.googlecode.com/svn/releases/"

--- a/src/appengine_magic/core_local.clj
+++ b/src/appengine_magic/core_local.clj
@@ -58,7 +58,10 @@
 
 (defn make-appengine-request-environment-filter []
   (reify javax.servlet.Filter
-    (init [_ _])
+    (init [_ filter-config]
+      (.setAttribute (.getServletContext filter-config)
+                     "com.google.appengine.devappserver.ApiProxyLocal"
+                     (ApiProxy/getDelegate)))
     (destroy [_])
     (doFilter [_ req resp chain]
       (let [all-cookies (.getCookies req)

--- a/src/appengine_magic/core_local.clj
+++ b/src/appengine_magic/core_local.clj
@@ -82,10 +82,11 @@
 (defonce ^{:dynamic true} *server* (atom nil))
 
 
-(defn start [appengine-app & {:keys [port join?] :or {port 8080, join? false}}]
+(defn start [appengine-app & {:keys [port join? high-replication in-memory]
+                              :or {port 8080, join? false, high-replication false, in-memory false}}]
   (let [war-root (java.io.File. (:war-root appengine-app))
         handler-servlet (servlet (:handler appengine-app))]
-    (appengine-init war-root port)
+    (appengine-init war-root port high-replication in-memory)
     (reset!
      *server*
      (jetty/start
@@ -135,6 +136,7 @@
     (reset! *server* nil)))
 
 
-(defn serve [appengine-app & {:keys [port] :or {port 8080}}]
+(defn serve [appengine-app & {:keys [port high-replication in-memory]
+                              :or {port 8080, high-replication false, in-memory false}}]
   (stop)
-  (start appengine-app :port port))
+  (start appengine-app :port port :high-replication high-replication :in-memory in-memory))

--- a/src/appengine_magic/local_env_helpers.clj
+++ b/src/appengine_magic/local_env_helpers.clj
@@ -26,7 +26,7 @@
     (getVersionId [] @*current-app-version*)))
 
 
-(defn appengine-init [#^File dir, port]
+(defn appengine-init [#^File dir, port high-replication in-memory]
   (let [appengine-web-file (File. dir "WEB-INF/appengine-web.xml")
         application-id (if (.exists appengine-web-file)
                            (first (xpath-value appengine-web-file "//application"))
@@ -47,6 +47,12 @@
     (reset! *current-app-id* application-id)
     (reset! *current-app-version* application-version)
     (reset! *current-server-port* port)
+
+    ;; Set datastore properties for optional features
+    (.setProperty api-proxy "datastore.no_storage" (str in-memory))
+    (if high-replication
+      (.setProperty api-proxy "datastore.default_high_rep_job_policy_unapplied_job_pct" "20"))
+
     (ApiProxy/setDelegate api-proxy)
     ;; This installs a thread environment onto the REPL thread and allows App
     ;; Engine API calls to work in the REPL.


### PR DESCRIPTION
A co-worker of mine added support for the 1.6.3.1 SDK
and optional High-Replication-Datastore and In-Memory Datastore for the dev server.

Hope you are still interested ;)

Best regards,
Tobias
