### PR TITLE
Don't count first when we're doing a real query.

### DIFF
--- a/src/appengine_magic/services/datastore.clj
+++ b/src/appengine_magic/services/datastore.clj
@@ -505,23 +505,22 @@
                            (.prepare (get-datastore-service) query-object))
         result-type (if (and (instance? Class kind) (extends? EntityProtocol kind))
                         kind
-                        entity-record-type)
-        result-count (.countEntities prepared-query fetch-options-object)]
-    (cond count-only? result-count
-          (zero? result-count) (list)
-          :else (let [results (seq (.asIterable prepared-query fetch-options-object))
-                      model-record (if result-type
-                                       ;; we know this type; good
-                                       (record result-type)
-                                       ;; unknown type; just use a basic EntityProtocol
-                                       (EntityBase.))]
-                  (map #(with-meta
-                          (run-after-load
-                           (merge model-record
-                                  (entity->properties (.getProperties %)
-                                                      (get-clj-properties model-record))))
-                          {:key (.getKey %)})
-                       results)))))
+                        entity-record-type)]
+    (if count-only?
+      (.countEntities prepared-query fetch-options-object)
+      (let [results (seq (.asIterable prepared-query fetch-options-object))
+            model-record (if result-type
+                             ;; we know this type; good
+                             (record result-type)
+                             ;; unknown type; just use a basic EntityProtocol
+                             (EntityBase.))]
+        (map #(with-meta
+                (run-after-load
+                 (merge model-record
+                        (entity->properties (.getProperties %)
+                                            (get-clj-properties model-record))))
+                {:key (.getKey %)})
+             results)))))
 
 
 (defmacro query


### PR DESCRIPTION
Using the appstats tool for my GAE project, I found that counting the entities in a query before executing it took about 160% as long as just executing the query (with no count).  Unless it is expected that most queries will return zero results, counting first doesn't make sense.
