### PR TITLE
getting rid of  compile errors on plugins appengine-prepare and appengine-update

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject appengine-magic "0.5.1-SNAPSHOT"
+(defproject org.clojars.intronic/appengine-magic "0.5.1-SNAPSHOT"
   :description "Google App Engine library for Clojure."
   :url "https://github.com/gcv/cupboard"
   :min-lein-version "2.0.0"
@@ -19,6 +19,8 @@
                  [javax.servlet/jstl "1.1.2"] ; repackaged-appengine-jakarta-jstl-1.1.2.jar
                  [taglibs/standard "1.1.2"] ; repackaged-appengine-jakarta-standard-1.1.2.jar
                  [commons-el "1.0"]
+                 ;; leiningen plugin
+                 [leiningen "2.0.0"]
                  ;; main App Engine libraries
                  [com.google.appengine/appengine-api-1.0-sdk "1.7.4"]
                  [com.google.appengine/appengine-api-labs "1.7.4"]

--- a/src/appengine_magic/leiningen_helpers.clj
+++ b/src/appengine_magic/leiningen_helpers.clj
@@ -1,6 +1,6 @@
 (ns appengine-magic.leiningen-helpers
   (:use appengine-magic.utils)
-  (:require [leiningen.core :as lein])
+  (:require [leiningen.core.main :as lein])
   (:import java.io.File
            com.google.appengine.tools.admin.AppCfg
            [org.apache.commons.exec CommandLine DefaultExecutor]))

--- a/src/leiningen/appengine_prepare.clj
+++ b/src/leiningen/appengine_prepare.clj
@@ -61,4 +61,4 @@
        compile-path-empty?
        (doseq [entry-name (.list compile-path)]
          (let [entry (File. compile-path entry-name)]
-           (leiningen.util.file/delete-file-recursively entry true)))))))
+           (leiningen.clean/delete-file-recursively entry true)))))))

--- a/src/leiningen/appengine_prepare.clj
+++ b/src/leiningen/appengine_prepare.clj
@@ -48,7 +48,7 @@
         ;; copy important dependencies into WEB-INF/lib
         ;; FIXME: This needs to exclude development-only dependencies.
         (lancet/copy {:todir (.getPath target-lib-dir)}
-                     (lancet/fileset {:dir lib-dir
+                     (lancet/fileset {:dir target-lib-dir
                                       :includes "*"}))))
     ;; Projects which do not normally use AOT may need some cleanup. This should
     ;; happen regardless of compilation success or failure.


### PR DESCRIPTION
The very first line you should ignore, I had to change my project name in order to push to my clojars group. Not sure how to do that without changing the project name.

-(defproject appengine-magic "0.5.1-SNAPSHOT"
+(defproject org.clojars.intronic/appengine-magic "0.5.1-SNAPSHOT"
- Leiningen 2.0.0 seems to have made a lot of namespace changes
- I'm not sure of the lancet/fileset change either, but the lib-dir symbol itself is not known.
